### PR TITLE
Fix file name typo when loading timestamps for face videos

### DIFF
--- a/src/datasources/common.py
+++ b/src/datasources/common.py
@@ -57,7 +57,7 @@ class VideoReader(object):
         if self.video_path.endswith('_eyes.mp4'):
             self.timestamps_path = video_path.replace('_eyes.mp4', '.timestamps.txt')
         elif self.video_path.endswith('_face.mp4'):
-            self.timestamps_path = video_path.replace('_eyes.mp4', '.timestamps.txt')
+            self.timestamps_path = video_path.replace('_face.mp4', '.timestamps.txt')
         elif self.video_path.endswith('.128x72.mp4'):
             self.timestamps_path = video_path.replace('.128x72.mp4', '.timestamps.txt')
         else:


### PR DESCRIPTION
When using the dataloading functions for the face patch videos, I encountered this bug that leads to trying to load a video file instead of text one with np.txt